### PR TITLE
Fix `InitWornArmor` CTD with RDF

### DIFF
--- a/src/main/Hooks.cpp
+++ b/src/main/Hooks.cpp
@@ -13,14 +13,15 @@ void Hooks::Install()
 
 void Hooks::InitWornArmor(
 	RE::TESObjectARMO* a_armor,
-	RE::Actor* a_actor,
-	RE::BSTSmartPointer<RE::BipedAnim>* a_biped)
+	RE::TESRace* a_race,
+	RE::BSTSmartPointer<RE::BipedAnim>* a_biped,
+	[[maybe_unused]] bool isFemale)
 {
-	auto race = a_actor->GetRace();
-	auto sex = a_actor->GetActorBase()->GetSex();
+	auto actor = a_biped->get()->actorRef.get().get()->As<RE::Actor>();
+	auto sex = actor->GetActorBase()->GetSex();
 
 	for (auto& armorAddon : a_armor->armorAddons) {
-		if (Ext::TESObjectARMA::HasRace(armorAddon, race)) {
+		if (Ext::TESObjectARMA::HasRace(armorAddon, a_race)) {
 
 			auto visitor = std::bind(
 				Ext::TESObjectARMA::InitWornArmorAddon,
@@ -29,7 +30,7 @@ void Hooks::InitWornArmor(
 				a_biped,
 				sex);
 
-			DynamicArmorManager::GetSingleton()->VisitArmorAddons(a_actor, armorAddon, visitor);
+			DynamicArmorManager::GetSingleton()->VisitArmorAddons(actor, armorAddon, visitor);
 		}
 	}
 }

--- a/src/main/Hooks.h
+++ b/src/main/Hooks.h
@@ -10,8 +10,9 @@ public:
 private:
 	static void InitWornArmor(
 		RE::TESObjectARMO* a_armor,
-		RE::Actor* a_actor,
-		RE::BSTSmartPointer<RE::BipedAnim>* a_biped);
+		RE::TESRace* a_race,
+		RE::BSTSmartPointer<RE::BipedAnim>* a_biped,
+		bool isFemale);
 
 	static auto GetWornMask(RE::InventoryChanges* a_inventoryChanges) -> BipedObjectSlot;
 };

--- a/src/main/Patches.cpp
+++ b/src/main/Patches.cpp
@@ -3,29 +3,13 @@
 
 void Patches::WriteInitWornPatch(InitWornArmorFunc* a_func)
 {
-	auto hook = util::MakeHook(RE::Offset::TESNPC::InitWornForm, 0x2F0);
+	auto hook = util::MakeHook(RE::Offset::TESNPC::InitWornForm, 0x302);
 
-	// Expected size: 0x12
-	struct Patch : public Xbyak::CodeGenerator
-	{
-		Patch(std::uintptr_t a_funcAddr)
-		{
-			mov(rdx, r13);
-			mov(rcx, rbp);
-			mov(rax, a_funcAddr);
-			call(rax);
-		}
-	};
+	auto& trampoline = SKSE::GetTrampoline();
+	SKSE::AllocTrampoline(14);
 
-	Patch patch{ reinterpret_cast<std::uintptr_t>(a_func) };
-	patch.ready();
+	trampoline.write_call<5>(hook.address(), reinterpret_cast<std::uintptr_t>(a_func));
 
-	if (patch.getSize() > 0x17) {
-		util::report_and_fail("Patch was too large, failed to install"sv);
-	}
-
-	REL::safe_fill(hook.address(), REL::NOP, 0x17);
-	REL::safe_write(hook.address(), patch.getCode(), patch.getSize());
 }
 
 void Patches::WriteGetWornMaskPatch(GetWornMaskFunc* a_func)

--- a/src/main/Patches.h
+++ b/src/main/Patches.h
@@ -4,8 +4,9 @@ namespace Patches
 {
 	using InitWornArmorFunc = void(
 		RE::TESObjectARMO* a_armor,
-		RE::Actor* a_actor,
-		RE::BSTSmartPointer<RE::BipedAnim>* a_biped);
+		RE::TESRace* a_race,
+		RE::BSTSmartPointer<RE::BipedAnim>* a_biped,
+		bool isFemale);
 
 	void WriteInitWornPatch(InitWornArmorFunc* a_func);
 


### PR DESCRIPTION
## Summary

This PR fixes the CTD between DAV and RDF ([Race Distribution Framework](https://www.nexusmods.com/skyrimspecialedition/mods/113825/?tab=posts&jump_to_comment=135473082&BH=2)). 

DAV's `WriteInitWornPatch` conflicts with RDF's [LoadTESObjectARMOHook](https://github.com/Nightfallstorm/RaceSwapper/blob/main/src/Hooks.cpp#L277), leading to CTD when the two mods are installed 

Original logic flow:

- DAV hooks `AddToBiped` call, using ASM to get the right arguments and jump to DAV hook
- RDF hooks `AddToBiped` call, using `write_thunk_call` on call site
- ASM is malformed from RDF's thunk setup, CTD occurs when invoked

New logic flow:
- DAV hooks `AddToBiped` call, using trampoline `write_call`
- RDF hooks `AddToBiped` call, using `write_thunk_call` on call site
- RDF hook runs first, switching out `race` argument to the NPC's new appearance race, if applicable
- DAV hook runs after, using the passed in `race` argument

This should let RDF successfully switch out the appearance race the armor will load under when necessary, while letting DAV get the right armor variants as needed.